### PR TITLE
fix(transcription): update the token help text markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Use valid markdown in the token help text URL
+
 ## [1.0.0] - 2025-05-12
 
 ### Added

--- a/src/creates/transcription.ts
+++ b/src/creates/transcription.ts
@@ -189,7 +189,7 @@ export default {
       key: 'copy',
       type: 'copy',
     }, {
-      helpText: "API token for Speech is Cheap.\nDon't have one? Sign up at https://speechischeap.com",
+      helpText: "API token for Speech is Cheap.\nDon't have one? Sign up at [speechischeap.com](https://speechischeap.com)",
       key: 'token',
       required: true,
       type: 'password',


### PR DESCRIPTION
Zapier is preventing me from publishing this integration until the help
text in the token input field is updated to use valid markdown. Per the
Zapier publishing tasks error, examples of correct implementations are:

```md
See [Google](https://google.com)
See `https://google.com`
```