### PR TITLE
feat(*): authenticate the Zapier way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Authentication mechanism as required by Zapier
+
 ### Changed
 
 - Sample transcript text to make it more clear that it's a sample

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Sample transcript text to make it more clear that it's a sample
+
 ## [1.0.1] - 2025-05-12
 
 ### Fixed

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,0 +1,20 @@
+import type { Authentication, Request } from 'zapier-platform-core';
+
+export default {
+  type: 'custom',
+
+  fields: [{
+    helpText: "API token for Speech is Cheap.\nDon't have one? Sign up at [speechischeap.com](https://speechischeap.com)",
+    key: 'token',
+    label: 'API Token',
+    required: true,
+    type: 'string',
+  }],
+
+  test: async (z, bundle) => {
+    await z.request({
+      headers: { Authorization: `Bearer ${bundle.authData.token}` },
+      url: 'https://api.speechischeap.com/v2/jobs/auth',
+    });
+  },
+} satisfies Authentication;

--- a/src/creates/transcription.ts
+++ b/src/creates/transcription.ts
@@ -79,7 +79,6 @@ const perform: PerformFunction = async (z, bundle) => {
 
   // Remove unexpected fields from the API payload:
   delete payload.can_include_json;
-  delete payload.token;
 
   // Validate payload:
   const validationErrors: string[] = [];
@@ -119,7 +118,7 @@ const perform: PerformFunction = async (z, bundle) => {
   try {
     apiResponse = await z.request({
       body: payload,
-      headers: { Authorization: `Bearer ${bundle.inputData.token}` },
+      headers: { Authorization: `Bearer ${bundle.authData.token}` },
       method: 'POST',
       url: 'https://api.speechischeap.com/v2/jobs/',
     });
@@ -188,11 +187,6 @@ export default {
       helpText: "The input URL depends on where the file is stored. Please [see the docs](https://docs.speechischeap.com/integrations/zapier) if you need additional help.",
       key: 'copy',
       type: 'copy',
-    }, {
-      helpText: "API token for Speech is Cheap.\nDon't have one? Sign up at [speechischeap.com](https://speechischeap.com)",
-      key: 'token',
-      required: true,
-      type: 'password',
     }, {
       helpText: 'Input URL of the audio file to transcribe.',
       key: 'input_url',

--- a/src/creates/transcription.ts
+++ b/src/creates/transcription.ts
@@ -59,7 +59,7 @@ const sampleTranscript: TranscriptionJob = {
         processing_duration_in_s: 0.321,
         seek: 1234.5,
         start: 1.234,
-        text: 'This is an example of some transcribed text output.',
+        text: 'SAMPLE. Publish Zap for the real transcription.',
         words: null
       }
     ]
@@ -68,7 +68,7 @@ const sampleTranscript: TranscriptionJob = {
 
 const sampleTranscriptWords = [{
   end: 1.345,
-  text: 'This',
+  text: 'SAMPLE.',
   start: 1.234,
 }];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import type { App } from 'zapier-platform-core';
 import { version as platformVersion } from 'zapier-platform-core';
 
+import authentication from './authentication';
 import packageJson from '../package.json';
 import TranscriptionCreate from './creates/transcription';
 
 export default {
+  authentication,
   creates: { [TranscriptionCreate.key]: TranscriptionCreate },
   platformVersion,
   version: packageJson.version,


### PR DESCRIPTION
Add a proper authentication mechanism as required by Zapier in section
["5.5 Integration requests authentication credentials appropriately"](https://docs.zapier.com/platform/publish/integration-publishing-requirements#5-5-integration-requests-authentication-credentials-appropriately) of
the Zapier Integration Publishing Requirements document. Updated due to
direct feedback from Zapier as they were testing version 1.0.1.

Note that this change removes the `token` input field and instead uses
the Zapier-provided `authData.token` parameter for the API token.

---

fix(transcription): clarify that it's a sample

When the user is testing the Zap, make it extra clear to the user that
they're getting back a sample transcription. This fix was inspired by
Matt Russo's feedback towards the end of this video recording:
https://komododecks.com/recordings/fbnkdruTJ9uBNi6gdLq3